### PR TITLE
Use binary data as HMAC key

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"flag"
 	"fmt"
-	"time"
 )
 
 func main() {
@@ -24,11 +25,17 @@ func main() {
 		runAPI(dal, *port)
 	} else {
 		if *app != "" {
-			app, err := dal.CreateApp(&App{Name: *app, Key: time.Now().Format(time.RFC3339Nano)})
+			randomkey := make([]byte, 256)
+			_, err := rand.Read(randomkey)
 			if err != nil {
-				fmt.Println(err)
+				fmt.Println("error getting random data:", err)
 			} else {
-				fmt.Println("app created, id:", app.Id, "key:", app.Key)
+				app, err := dal.CreateApp(&App{Name: *app, Key: randomkey})
+				if err != nil {
+					fmt.Println(err)
+				} else {
+					fmt.Println("app created, id:", app.Id, "key:", base64.StdEncoding.EncodeToString(app.Key))
+				}
 			}
 		} else {
 			err := dal.CreateKey(&Key{Name: *name, Public: *pub, Secret: *secret})


### PR DESCRIPTION
The application key stored in base64 in the database is now decoded
before being used as key in HMAC. This fixes signature validation
problems with Auth/Yubico.php, used - for example - in simpleid-yubikey.

Previously, the ASCII representation of the base64 encoded key was used
as HMAC key, which generated different signatures. This change is not
backwards compatible: it will break any clients that have so far
successfully validated the signatures.

Since the date and time of application creation was used as seed for the
generated key, but a string is not easily convertible into raw bytes
(and is potentially low-entropy), switch to 256 (cryptographically
secure) random bytes as key initialization.

See neverpanic/simpleid-yubikey#1

Signed-off-by: Clemens Lang neverpanic@gmail.com
