### PR TITLE
new argument 'host' to change the address where the server will listen for requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+database.db
+yubikey-server
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/api.go
+++ b/api.go
@@ -106,7 +106,7 @@ func reply(w http.ResponseWriter, otp, name, nonce, status, id string, dal *Dal)
 	w.Write([]byte(ret))
 }
 
-func runAPI(dal *Dal, port string) {
+func runAPI(dal *Dal, host, port string) {
 	r := mux.NewRouter()
 
 	r.HandleFunc("/wsapi/2.0/verify", func(w http.ResponseWriter, r *http.Request) {
@@ -114,6 +114,6 @@ func runAPI(dal *Dal, port string) {
 	}).Methods("GET")
 
 	http.Handle("/", r)
-	log.Println("Listening on port " + port + "...")
-	http.ListenAndServe(":"+port, nil)
+	log.Printf("Listening on: %s:%s...", host, port)
+	http.ListenAndServe(host+":"+port, nil)
 }

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 	secret := flag.String("secret", "", "secret key")
 	app := flag.String("app", "", "application name")
 	port := flag.String("p", "4242", "server port")
+	host := flag.String("host", "127.0.0.1", "server addr")
 	flag.Parse()
 
 	dal, err := newDAL()
@@ -23,7 +24,7 @@ func main() {
 	}
 
 	if *serverMode {
-		runAPI(dal, *port)
+		runAPI(dal, *host, *port)
 	} else {
 		if *app != "" {
 			randomkey := make([]byte, 256)


### PR DESCRIPTION
Usefull for internal –not exposed– API, for docker network topologies or for machines with several network interfaces.
