### PR TITLE
Support relocating the database file

### DIFF
--- a/dal.go
+++ b/dal.go
@@ -29,8 +29,8 @@ type App struct {
 	Key  []byte
 }
 
-func newDAL() (*Dal, error) {
-	d, err := sql.Open("sqlite3", "./database.db")
+func newDAL(dbfile string) (*Dal, error) {
+	d, err := sql.Open("sqlite3", dbfile)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -16,9 +16,10 @@ func main() {
 	app := flag.String("app", "", "application name")
 	port := flag.String("p", "4242", "server port")
 	host := flag.String("host", "127.0.0.1", "server addr")
+	db := flag.String("db", "database.db", "database file")
 	flag.Parse()
 
-	dal, err := newDAL()
+	dal, err := newDAL(*db)
 	if err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
Allow relocating the database file elsewhere on disk, while maintaining the default behaviour to create database.db next to the binary.
